### PR TITLE
Add DS_store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules/
+.DS_Store


### PR DESCRIPTION
DS_Store is not a file you want in the repo. It macOS specifically, and to my knowledge it is often globally ignored or added to the gitignore.